### PR TITLE
Silence logging while detecting devices

### DIFF
--- a/lib/core/device.js
+++ b/lib/core/device.js
@@ -37,8 +37,14 @@ device._deviceDrivers = {
 };
 
 device._deviceComms = {
-  'DexcomG4': serialDevice()
+  'DexcomG4': serialDevice
 };
+device._silentComms = {};
+_.forEach(_.keys(device._deviceComms), function(driverId) {
+  var comm = device._deviceComms[driverId];
+  device._silentComms[driverId] = comm({silent: true});
+  device._deviceComms[driverId] = comm();
+});
 
 device.init = function(options, cb) {
   this._defaultTimezone = options.defaultTimezone;
@@ -87,7 +93,8 @@ device.getDriverManifest = function(driverId) {
 };
 
 device.detectHelper = function(driverId, cb) {
-  var dm = this._createDriverManager(driverId);
+  // Detect can run on a loop, so don't polute the console with logging
+  var dm = this._createDriverManager(driverId, {silent: true});
   dm.detect(driverId, cb);
 };
 
@@ -102,13 +109,15 @@ device._createDriverManager = function(driverId, options) {
 device._createDriverConfig = function(driverId, options) {
   options = options || {};
   var timezone = options.timezone || this._defaultTimezone;
+  var comms = options.silent ? this._silentComms : this._deviceComms;
   return {
-    deviceComms: this._deviceComms[driverId],
+    deviceComms: comms[driverId],
     timeutils: timeutils,
     timezone: timezone,
     jellyfish: this._jellyfish,
     builder: builder,
-    progress: options.progress
+    progress: options.progress,
+    silent: Boolean(options.silent)
   };
 };
 

--- a/lib/dexcomDriver.js
+++ b/lib/dexcomDriver.js
@@ -27,6 +27,10 @@ module.exports = function (config) {
   var cfg = _.clone(config);
   var serialDevice = config.deviceComms;
 
+  if (config.silent) {
+    debug = _.noop;
+  }
+
   var SYNC_BYTE = 0x01;
 
   var CMDS = {

--- a/lib/driverManager.js
+++ b/lib/driverManager.js
@@ -61,7 +61,7 @@ module.exports = function (driverObjects, configs) {
 
   return {
     detect: function(driver, cb) {
-      // if the driver supplies a detect function, call it, but if not, 
+      // if the driver supplies a detect function, call it, but if not,
       // we call the first three upload functions with a noop progress function.
       if (drivers[driver].detect) {
         drivers[driver].detect(cb);
@@ -79,10 +79,10 @@ module.exports = function (driverObjects, configs) {
             } else {
               var pid = result.firmwareHeader.attrs.ProductId;
               var sn = result.manufacturing_data.attrs.SerialNumber;
-              cb(null, { 
-                model: pid, 
-                serialNumber: sn, 
-                id: pid + ' ' + sn 
+              cb(null, {
+                model: pid,
+                serialNumber: sn,
+                id: pid + ' ' + sn
               });
             }
           });

--- a/lib/serialDevice.js
+++ b/lib/serialDevice.js
@@ -24,6 +24,7 @@ var debug = require('./bows')('SerialDevice');
 var moduleCounter = 1;
 
 module.exports = function(config) {
+  config = config || {};
   var connected = false;
   var connection = null;
   var port = null;
@@ -37,6 +38,10 @@ module.exports = function(config) {
   var logcount = 0;
   var loglimit = 400;
   var doLogging = (config && config.doLogging) || false;
+
+  if (config.silent) {
+    debug = _.noop;
+  }
 
   function init() {
     connected = false;


### PR DESCRIPTION
@kentquirk Do you mind taking a look at this? It was getting a bit painful to debug things with the continuous scanning, so tried to do something about the logging. It feels a bit of a hack, but it's the best I could come up with right now. Feel free to share any other suggestions :)

Btw, related to this, I also added on `mvp` the possibility to stop the scanning from the JavaScript console:

```
> app.refs.scan.stopScanning();
> app.refs.scan.startScanning();
```
