### PR TITLE
Hotfix v2.28.1 (UPLOAD-325)

### DIFF
--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -137,13 +137,7 @@ operating system, as soon as possible.`,
       // no chrome installs found, open user's default browser
       open(url);
     } else {
-      let app;
-      if(platform === 'win32'){
-        app = `"${chromeInstalls[0]}"`;
-      } else {
-        app = chromeInstalls[0];
-      }
-      open(url, {app}, function(error){
+      open(url, {app: chromeInstalls[0]}, function(error){
         if(error){
           // couldn't open chrome, try OS default
           open(url);

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.prod.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.prod.js",


### PR DESCRIPTION
Fixes [UPLOAD-325]. We [implemented a workaround](https://github.com/tidepool-org/uploader/commit/22360774c17c4a917ceedb8626409f76eb92f1c8) for a bug in `open`, which was fixed (https://github.com/sindresorhus/open/pull/172/files) in the v7.0.3 update that was released as part of Uploader v2.28.0 (https://github.com/tidepool-org/uploader/pull/1097)
Unfortunately that meant that our workaround breaks things. This PR removes the workaround now that `open` is fixed.

[UPLOAD-325]: https://tidepool.atlassian.net/browse/UPLOAD-325