### PR TITLE
Update .bookignore file

### DIFF
--- a/.bookignore
+++ b/.bookignore
@@ -29,3 +29,9 @@ manifest.json
 package.json
 update-gh-pages.sh
 yarn.lock
+.dockerignore
+.env
+Dockerfile
+docker-compose.yaml
+entrypoint.sh
+locales/


### PR DESCRIPTION
We haven't published the updated docs to https://developer.tidepool.org/uploader in a long time, so when I just did this I had to update the .bookignore file for Gitbook.