### PR TITLE
Upload binaries to Kaspersky using secure FTP

### DIFF
--- a/scripts/whitelisting/av-submit.js
+++ b/scripts/whitelisting/av-submit.js
@@ -100,6 +100,9 @@ function sendToKaspersky(downloadURL) {
       c.connect({
         host : 'allowlist.kaspersky-labs.com',
         user : 'wl-Tidepool',
+        port : 990,
+        secure : true,
+        secureOptions: { rejectUnauthorized: false },
         password: process.env.FTP_AV_PASSWORD_TIDEPOOL
       });
     });


### PR DESCRIPTION
We received a notification from Kaspersky that they will only allow uploads via secure FTP going forward. As this is not a user-facing change and doesn't affect the Uploader code, there's no associated Jira ticket.