### PR TITLE
MacOS Monterey (UPLOAD-688)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.39.0-monterey-fix.1",
+  "version": "2.39.0",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.prod.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.39.0-monterey-fix.1",
+  "version": "2.39.0",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.prod.js",


### PR DESCRIPTION
Turns out it's a dependency we use (`os-name`, to determine which OS version is in use) that was breaking things. See [UPLOAD-688] for details.

[UPLOAD-688]: https://tidepool.atlassian.net/browse/UPLOAD-688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ