### PR TITLE
[UPLOAD-692] replace 'personal' with 'private'

### DIFF
--- a/app/actions/async.js
+++ b/app/actions/async.js
@@ -809,7 +809,7 @@ export function retrieveTargetsFromStorage() {
   };
 }
 
-export function goToPersonalWorkspace() {
+export function goToPrivateWorkspace() {
   return (dispatch, getState) => {
     const { loggedInUser, uploadTargetUser, devices, targetDevices, targetTimezones} = getState();
 

--- a/app/components/ClinicUserSelect.js
+++ b/app/components/ClinicUserSelect.js
@@ -45,7 +45,7 @@ class ClinicUserSelect extends React.Component {
     blipUrls: PropTypes.object.isRequired,
     loggedInUser: PropTypes.string.isRequired,
     onGoToWorkspaceSwitch: PropTypes.func.isRequired,
-    goToPersonalWorkspace: PropTypes.func.isRequired,
+    goToPrivateWorkspace: PropTypes.func.isRequired,
   };
 
   constructor(props) {
@@ -78,9 +78,9 @@ class ClinicUserSelect extends React.Component {
     this.props.onSetSelectedClinicId(clinic.id);
   }
 
-  handleSwitchToPersonal = (e) => {
+  handleSwitchToPrivate = (e) => {
     e.preventDefault();
-    this.props.goToPersonalWorkspace();
+    this.props.goToPrivateWorkspace();
   }
 
   handleWorkspaceSwitch = (e) => {
@@ -269,14 +269,14 @@ class ClinicUserSelect extends React.Component {
     }
   }
 
-  renderPersonalWorkspaceLink = () => {
+  renderPrivateWorkspaceLink = () => {
     const {loggedInUser, allUsers} = this.props;
     const user = allUsers[loggedInUser];
-    const hasPersonalWorkspace = _.get(user, ['profile', 'patient'], false);
-    if(hasPersonalWorkspace) {
+    const hasPrivateWorkspace = _.get(user, ['profile', 'patient'], false);
+    if(hasPrivateWorkspace) {
       return (
         <div className={styles.postScript}>
-          {i18n.t('Want to use Tidepool for your personal data?')}  <a href="" onClick={this.handleSwitchToPersonal}>{i18n.t('Go to Personal Workspace')}</a>
+          {i18n.t('Want to use Tidepool for your private data?')}  <a href="" onClick={this.handleSwitchToPrivate}>{i18n.t('Go to Private Workspace')}</a>
         </div>
       );
     }
@@ -303,7 +303,7 @@ class ClinicUserSelect extends React.Component {
         </div>
       </div>
       {this.renderWebOrSwitchLink()}
-      {this.renderPersonalWorkspaceLink()}
+      {this.renderPrivateWorkspaceLink()}
       </>
     );
   }

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -79,10 +79,10 @@ export class Header extends Component {
     toggleDropdown(true, actionSources.UNDER_THE_HOOD);
   }
 
-  handlePersonalWorkspaceSwitch = () => {
+  handlePrivateWorkspaceSwitch = () => {
     const { toggleDropdown } = this.props.sync;
-    const { goToPersonalWorkspace } = this.props.async;
-    goToPersonalWorkspace();
+    const { goToPrivateWorkspace } = this.props.async;
+    goToPrivateWorkspace();
     toggleDropdown(true, actionSources.UNDER_THE_HOOD);
   }
 
@@ -125,9 +125,9 @@ export class Header extends Component {
             user={allUsers[this.props.loggedInUser]}
             targetUsersForUpload={this.props.targetUsersForUpload}
             clinics={this.props.clinics}
-            hasPersonalWorkspace={this.props.hasPersonalWorkspace}
+            hasPrivateWorkspace={this.props.hasPrivateWorkspace}
             onWorkspaceSwitch={this.handleWorkspaceSwitch}
-            goToPersonalWorkspace={this.handlePersonalWorkspaceSwitch}
+            goToPrivateWorkspace={this.handlePrivateWorkspaceSwitch}
             switchToClinic={this.handleSwitchToClinic}
             isClinicMember={this.props.isClinicMember}
             uploadTargetUser={this.props.uploadTargetUser}
@@ -140,7 +140,7 @@ export class Header extends Component {
 
 export default connect(
   (state, ownProps) => {
-    function hasPersonalWorkspace(state){
+    function hasPrivateWorkspace(state){
       return !!_.get(_.get(state.allUsers, state.loggedInUser, {}), ['profile', 'patient'], false);
     }
     function isClinicMember(state) {
@@ -158,7 +158,7 @@ export default connect(
       uploadTargetUser: state.uploadTargetUser,
       loggedInUser: state.loggedInUser,
       // derived state
-      hasPersonalWorkspace: hasPersonalWorkspace(state),
+      hasPrivateWorkspace: hasPrivateWorkspace(state),
       isClinicMember: isClinicMember(state),
     };
   },

--- a/app/components/LoggedInAs.js
+++ b/app/components/LoggedInAs.js
@@ -40,9 +40,9 @@ export default class LoggedInAs extends Component {
     user: PropTypes.object,
     targetUsersForUpload: PropTypes.array,
     clinics: PropTypes.object,
-    hasPersonalWorkspace: PropTypes.bool,
+    hasPrivateWorkspace: PropTypes.bool,
     onWorkspaceSwitch: PropTypes.func.isRequired,
-    goToPersonalWorkspace: PropTypes.func.isRequired,
+    goToPrivateWorkspace: PropTypes.func.isRequired,
     switchToClinic: PropTypes.func.isRequired,
     isClinicMember: PropTypes.bool.isRequired,
     uploadTargetUser: PropTypes.string,
@@ -91,9 +91,9 @@ export default class LoggedInAs extends Component {
     this.props.onWorkspaceSwitch();
   };
 
-  handleSwitchToPersonal = e => {
+  handleSwitchToPrivate = e => {
     e.preventDefault();
-    this.props.goToPersonalWorkspace();
+    this.props.goToPrivateWorkspace();
   }
 
   handleSwitchToClinic = clinic => {
@@ -104,13 +104,13 @@ export default class LoggedInAs extends Component {
     var title = '';
     var uploadInProgress = this.props.isUploadInProgress;
     var isDisabled = uploadInProgress;
-    var {hasPersonalWorkspace, loggedInUser, uploadTargetUser} = this.props;
+    var {hasPrivateWorkspace, loggedInUser, uploadTargetUser} = this.props;
 
     if(uploadTargetUser !== loggedInUser) {
       return null;
     }
 
-    if (_.isEmpty(this.props.targetUsersForUpload) && !hasPersonalWorkspace) {
+    if (_.isEmpty(this.props.targetUsersForUpload) && !hasPrivateWorkspace) {
      isDisabled = true;
     }
 
@@ -149,7 +149,7 @@ export default class LoggedInAs extends Component {
   }
 
   renderWorkspaces() {
-    var {clinics, hasPersonalWorkspace} = this.props;
+    var {clinics, hasPrivateWorkspace} = this.props;
     var clinicIds = _.keys(clinics);
     if(clinicIds.length > 1){
       return (
@@ -164,7 +164,7 @@ export default class LoggedInAs extends Component {
         </li>
       );
     }
-    if(clinicIds.length == 1 && hasPersonalWorkspace){
+    if(clinicIds.length == 1 && hasPrivateWorkspace){
       return (
         <li>
           <a className={styles.muiLink}
@@ -182,17 +182,17 @@ export default class LoggedInAs extends Component {
     }
   }
 
-  renderPersonalWorkspace() {
-    var {hasPersonalWorkspace, isClinicMember} = this.props;
-    if(hasPersonalWorkspace && isClinicMember) {
+  renderPrivateWorkspace() {
+    var {hasPrivateWorkspace, isClinicMember} = this.props;
+    if(hasPrivateWorkspace && isClinicMember) {
       return (
         <li>
           <a className={styles.muiLink}
-            onClick={this.handleSwitchToPersonal}
+            onClick={this.handleSwitchToPrivate}
             href=""
-            title={i18n.t('Personal Workspace')}>
-              <SupervisedUserCircleIcon classes={{root:styles.personalWorkspaceIcon}} fontSize='inherit' />
-              {i18n.t('Personal Workspace')}
+            title={i18n.t('Private Workspace')}>
+              <SupervisedUserCircleIcon classes={{root:styles.privateWorkspaceIcon}} fontSize='inherit' />
+              {i18n.t('Private Workspace')}
             </a>
         </li>
       );
@@ -228,7 +228,7 @@ export default class LoggedInAs extends Component {
           {this.renderChooseDevices()}
           {this.renderCheckForUpdates()}
           {this.renderWorkspaces()}
-          {this.renderPersonalWorkspace()}
+          {this.renderPrivateWorkspace()}
           <li>{this.renderLogout()}</li>
         </ul>
       </div>

--- a/app/containers/ClinicUserSelectPage.js
+++ b/app/containers/ClinicUserSelectPage.js
@@ -65,7 +65,7 @@ export class ClinicUserSelectPage extends Component {
           blipUrls={blipUrls}
           loggedInUser={loggedInUser}
           onGoToWorkspaceSwitch={this.onGoToWorkspaceSwitch}
-          goToPersonalWorkspace={this.props.async.goToPersonalWorkspace} />
+          goToPrivateWorkspace={this.props.async.goToPrivateWorkspace} />
       </div>
     );
   }

--- a/app/containers/WorkspacePage.js
+++ b/app/containers/WorkspacePage.js
@@ -18,6 +18,8 @@ export const WorkspacePage = (props) => {
   const dispatch = useDispatch();
   const clinics = useSelector((state)=>state.clinics);
   const blipUrls = useSelector((state)=>state.blipUrls);
+  const loggedInUser = useSelector((state)=>state.loggedInUser);
+  const allUsers = useSelector((state)=>state.allUsers);
 
   const handleSwitchWorkspace = (clinic) => {
     dispatch(sync.setUploadTargetUser(null));
@@ -28,6 +30,23 @@ export const WorkspacePage = (props) => {
         metric: { eventName: metrics.CLINIC_SEARCH_DISPLAYED },
       })
     );
+  };
+
+  const handleSwitchToPrivate = (e) => {
+    e.preventDefault();
+    dispatch(async.goToPrivateWorkspace());
+  };
+
+  const renderPrivateWorkspaceLink = () => {
+    const user = allUsers[loggedInUser];
+    const hasPrivateWorkspace = !!user?.profile?.patient;
+    if(hasPrivateWorkspace) {
+      return (
+        <div className={styles.postScript}>
+          {i18n.t('Want to use Tidepool for your private data?')}  <a href="" onClick={handleSwitchToPrivate}>{i18n.t('Go to Private Workspace')}</a>
+        </div>
+      );
+    }
   };
 
   return (
@@ -49,6 +68,7 @@ export const WorkspacePage = (props) => {
             </div>
           )}
         </div>
+        {renderPrivateWorkspaceLink()}
       </div>
     </div>
   );

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.38.1-new-clinics.5",
+  "version": "2.38.1-personal-private.1",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.prod.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.38.1-new-clinics.5",
+  "version": "2.38.1-personal-private.1",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.prod.js",

--- a/styles/components/LoggedInAs.module.less
+++ b/styles/components/LoggedInAs.module.less
@@ -110,7 +110,7 @@
   composes: muiIcon
 }
 
-.personalWorkspaceIcon {
+.privateWorkspaceIcon {
   composes: icon-profile from '../core/icons.module.less';
 }
 

--- a/styles/components/WorkspacePage.module.less
+++ b/styles/components/WorkspacePage.module.less
@@ -97,3 +97,20 @@
   margin-bottom: 20px;
   color: red;
 }
+
+.postScript {
+  composes: gray from '../core/typography.module.less';
+  width: 570px;
+  margin: 32px auto;
+
+  a {
+    color: @link-color;
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      color: @link-hover-color;
+      text-decoration: underline;
+    }
+  }
+}

--- a/test/app/actions/async.test.js
+++ b/test/app/actions/async.test.js
@@ -3862,7 +3862,7 @@ describe('Asynchronous Actions', () => {
     });
   });
 
-  describe('goToPersonalWorkspace', () => {
+  describe('goToPrivateWorkspace', () => {
     const blipUrlMaker = (path) => { return 'http://acme-blip.com' + path; };
     const profile = {
       fullName: 'John',
@@ -3953,7 +3953,7 @@ describe('Asynchronous Actions', () => {
             abc123: 'US/Mountain'
           }
         });
-        store.dispatch(async.goToPersonalWorkspace());
+        store.dispatch(async.goToPrivateWorkspace());
         const actions = store.getActions();
         expect(actions).to.deep.equal(expectedActions);
       });
@@ -4017,7 +4017,7 @@ describe('Asynchronous Actions', () => {
           targetsForUpload: ['abc123', 'def456'],
           uploadTargetUser: 'abc123'
         });
-        store.dispatch(async.goToPersonalWorkspace());
+        store.dispatch(async.goToPrivateWorkspace());
         const actions = store.getActions();
         expect(actions).to.deep.equal(expectedActions);
       });
@@ -4098,7 +4098,7 @@ describe('Asynchronous Actions', () => {
             abc123: 'US/Mountain'
           }
         });
-        store.dispatch(async.goToPersonalWorkspace());
+        store.dispatch(async.goToPrivateWorkspace());
         const actions = store.getActions();
         expect(actions).to.deep.equal(expectedActions);
       });


### PR DESCRIPTION
For [UPLOAD-692] mostly just replacing "Personal" with "Private" for referencing workspaces. Also tacks in missing "go to private workspace" link on the workspace switcher page (if the user has one)

This targets the clinic workspaces branch since that's where testing will happen.

[UPLOAD-692]: https://tidepool.atlassian.net/browse/UPLOAD-692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ