### PR TITLE
[UPLOAD-693] classic clinic interface

### DIFF
--- a/app/components/ClinicUserEdit.js
+++ b/app/components/ClinicUserEdit.js
@@ -369,11 +369,11 @@ function mapStateToProps(state){
         initialValues = {
           initialValues: {
             fullName: personUtils.patientFullName(user),
-            year: _.get(user, ['patient', 'birthday'], '').substr(0,4),
-            month: _.get(user, ['patient', 'birthday'], '').substr(5,2),
-            day: _.get(user, ['patient', 'birthday'], '').substr(8,2),
-            email: _.get(user, ['patient', 'email'], ''),
-            mrn: _.get(user, ['patient', 'mrn'], '')
+            year: _.get(user, ['profile', 'patient', 'birthday'], '').substr(0,4),
+            month: _.get(user, ['profile', 'patient', 'birthday'], '').substr(5,2),
+            day: _.get(user, ['profile', 'patient', 'birthday'], '').substr(8,2),
+            email: _.get(user, ['profile', 'patient', 'email'], ''),
+            mrn: _.get(user, ['profile', 'patient', 'mrn'], '')
           }
         };
       }

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -141,7 +141,9 @@ export class Header extends Component {
 export default connect(
   (state, ownProps) => {
     function hasPrivateWorkspace(state){
-      return !!_.get(_.get(state.allUsers, state.loggedInUser, {}), ['profile', 'patient'], false);
+      const hasPatientProfile = !!_.get(_.get(state.allUsers, state.loggedInUser, {}), ['profile', 'patient'], false);
+      const hasTargetUsersForUpload = !_.isEmpty(state.targetUsersForUpload);
+      return hasPatientProfile || hasTargetUsersForUpload;
     }
     function isClinicMember(state) {
       return !!_.get(state.allUsers, [state.loggedInUser, 'isClinicMember'], false);

--- a/app/containers/WorkspacePage.js
+++ b/app/containers/WorkspacePage.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import map from 'lodash/map';
+import isEmpty from 'lodash/isEmpty';
 
 import * as metrics from '../constants/metrics';
 import { pages } from '../constants/otherConstants';
@@ -20,6 +21,7 @@ export const WorkspacePage = (props) => {
   const blipUrls = useSelector((state)=>state.blipUrls);
   const loggedInUser = useSelector((state)=>state.loggedInUser);
   const allUsers = useSelector((state)=>state.allUsers);
+  const targetUsersForUpload = useSelector((state)=>state.targetUsersForUpload);
 
   const handleSwitchWorkspace = (clinic) => {
     dispatch(sync.setUploadTargetUser(null));
@@ -39,8 +41,9 @@ export const WorkspacePage = (props) => {
 
   const renderPrivateWorkspaceLink = () => {
     const user = allUsers[loggedInUser];
-    const hasPrivateWorkspace = !!user?.profile?.patient;
-    if(hasPrivateWorkspace) {
+    const hasPatientProfile = !!user?.profile?.patient;
+    const hasTargetUsersForUpload = !isEmpty(targetUsersForUpload);
+    if(hasPatientProfile || hasTargetUsersForUpload) {
       return (
         <div className={styles.postScript}>
           {i18n.t('Want to use Tidepool for your private data?')}  <a href="" onClick={handleSwitchToPrivate}>{i18n.t('Go to Private Workspace')}</a>

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.38.1-personal-private.1",
+  "version": "2.38.1-classic-clinic.1",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.prod.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.38.1-personal-private.1",
+  "version": "2.38.1-classic-clinic.1",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.prod.js",

--- a/test/app/actions/async.test.js
+++ b/test/app/actions/async.test.js
@@ -2458,7 +2458,7 @@ describe('Asynchronous Actions', () => {
           },
           uploadTargetUser: 'abc123',
           allUsers: {
-            abc123: profile
+            abc123: {profile}
           }
         };
         const store = mockStore(state);
@@ -3141,7 +3141,7 @@ describe('Asynchronous Actions', () => {
           },
           uploadTargetUser: 'abc123',
           allUsers: {
-            abc123: profile
+            abc123: {profile}
           }
         };
         const store = mockStore(state);
@@ -3585,7 +3585,7 @@ describe('Asynchronous Actions', () => {
         const store = mockStore({
           allUsers: {
             ghi789: {},
-            abc123: profile,
+            abc123: {profile},
             def456: {},
           },
           devices: {
@@ -3840,7 +3840,7 @@ describe('Asynchronous Actions', () => {
         const store = mockStore({
           allUsers: {
             ghi789: {},
-            abc123: profile,
+            abc123: {profile},
             def456: {},
           },
           devices: {
@@ -3870,8 +3870,8 @@ describe('Asynchronous Actions', () => {
       birthday: '1990-08-08'
       }
     };
-    describe('user is missing timezone', () => {
-      test('should dispatch SELECT_CLINIC, SET_UPLOAD_TARGET_USER, SET_UPLOADS, then SET_PAGE (redirect to main page for timezone selection)', () => {
+    describe('user is clinician account', () => {
+      test('should dispatch SELECT_CLINIC, then SET_PAGE (redirect to clinic user select page)', () => {
         const targets = {
           abc123: [{key: 'carelink'}],
           def456: [
@@ -3889,24 +3889,10 @@ describe('Asynchronous Actions', () => {
             payload: { clinicId: null }
           },
           {
-            type: actionTypes.SET_UPLOAD_TARGET_USER,
-            payload: { userId: 'ghi789' },
-            meta: {source: actionSources[actionTypes.SET_UPLOAD_TARGET_USER]}
-          },
-          {
-            type: actionTypes.SET_UPLOADS,
-            payload: {
-              devicesByUser: {
-                abc123: [ 'carelink' ]
-              },
-            },
-            meta: {source: actionSources[actionTypes.SET_UPLOADS]},
-          },
-          {
             type: '@@router/CALL_HISTORY_METHOD',
             payload: {
               args: [ {
-                pathname: '/main',
+                pathname: '/clinic_user_select',
                 state: {
                   meta: {source: actionSources[actionTypes.SET_PAGE]}
                 }
@@ -3934,7 +3920,7 @@ describe('Asynchronous Actions', () => {
         });
         const store = mockStore({
           allUsers: {
-            ghi789: {},
+            ghi789: {isClinicMember: true},
             abc123: profile,
             def456: {},
           },
@@ -3958,8 +3944,8 @@ describe('Asynchronous Actions', () => {
         expect(actions).to.deep.equal(expectedActions);
       });
     });
-    describe('user has no supported devices', () => {
-      test('should dispatch SELECT_CLINIC, SET_UPLOAD_TARGET_USER, then SET_PAGE (redirect to settings page for device selection)', () => {
+    describe('user is not clinician account', () => {
+      test('should dispatch SELECT_CLINIC, then SET_PAGE (redirect to main page)', () => {
         const targets = {
           abc123: [{key: 'carelink', timezone: 'US/Eastern'}],
           def456: [
@@ -3977,15 +3963,10 @@ describe('Asynchronous Actions', () => {
             payload: { clinicId: null }
           },
           {
-            type: actionTypes.SET_UPLOAD_TARGET_USER,
-            payload: { userId: 'ghi789' },
-            meta: {source: actionSources[actionTypes.SET_UPLOAD_TARGET_USER]}
-          },
-          {
             type: '@@router/CALL_HISTORY_METHOD',
             payload: {
               args: [ {
-                pathname: '/settings',
+                pathname: '/main',
                 state: {
                   meta: {source: actionSources[actionTypes.SET_PAGE]}
                 }
@@ -4016,87 +3997,6 @@ describe('Asynchronous Actions', () => {
           loggedInUser: 'ghi789',
           targetsForUpload: ['abc123', 'def456'],
           uploadTargetUser: 'abc123'
-        });
-        store.dispatch(async.goToPrivateWorkspace());
-        const actions = store.getActions();
-        expect(actions).to.deep.equal(expectedActions);
-      });
-    });
-    describe('user is all set to upload', () => {
-      test('should dispatch SELECT_CLINIC, SET_UPLOAD_TARGET_USER, SET_UPLOADS, then SET_PAGE (redirect to main page)', () => {
-        const targets = {
-          abc123: [{key: 'carelink', timezone: 'US/Eastern'}],
-          def456: [
-            {key: 'dexcom', timezone: 'US/Mountain'},
-            {key: 'omnipod', timezone: 'US/Mountain'}
-          ]
-        };
-        const devicesByUser = {
-          abc123: ['carelink'],
-          def456: ['dexcom', 'omnipod']
-        };
-        const expectedActions = [
-          {
-            type: actionTypes.SELECT_CLINIC,
-            payload: { clinicId: null }
-          },
-          {
-            type: actionTypes.SET_UPLOAD_TARGET_USER,
-            payload: { userId: 'ghi789' },
-            meta: {source: actionSources[actionTypes.SET_UPLOAD_TARGET_USER]}
-          },
-          {
-            type: actionTypes.SET_UPLOADS,
-            payload: { devicesByUser },
-            meta: {source: actionSources[actionTypes.SET_UPLOADS]}
-          },
-          {
-            type: '@@router/CALL_HISTORY_METHOD',
-            payload: {
-              args: [ {
-                pathname: '/main',
-                state: {
-                  meta: {source: actionSources[actionTypes.SET_PAGE]}
-                }
-              } ],
-              method: 'push'
-            }
-          }
-        ];
-        __Rewire__('services', {
-          api: {
-            user: {
-              profile: (cb) => {
-                cb(null);
-              },
-              updateProfile: (user, update, cb) => {
-                cb(null, profile);
-              }
-            },
-            makeBlipUrl: blipUrlMaker
-          },
-          localStore: {
-            getItem: () => targets,
-            removeItem: (item) => null
-          }
-        });
-        const store = mockStore({
-          allUsers: {
-            ghi789: {},
-            abc123: profile,
-            def456: {},
-          },
-          devices: {
-            carelink: {},
-            dexcom: {},
-            omnipod: {}
-          },
-          loggedInUser: 'ghi789',
-          uploadTargetUser: 'abc123',
-          targetDevices: devicesByUser,
-          targetTimezones: {
-            abc123: 'US/Mountain'
-          }
         });
         store.dispatch(async.goToPrivateWorkspace());
         const actions = store.getActions();


### PR DESCRIPTION
For [UPLOAD-693], re-tools when/how we display the "private workspace" for the new clinicians, bringing back the clinic interface for the private workspace instead of directly pushing the user to upload for themselves.

Also takes care of a few instances of places that needed to be updated to reflect Uploader's update to match Blip's `allUsers` state (where Uploader previously just had the user's profile, now we have the whole user object to mirror Blip). 

Again, this targets the `workspaces` branch since we don't want to merge into `master` until the clinics updates get tested as a while.

[UPLOAD-693]: https://tidepool.atlassian.net/browse/UPLOAD-693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ