### PR TITLE
[UPLOAD-723] add patientid

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.40.1-new-clinics.13",
+  "version": "2.40.1-add-patientId.1",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.prod.js",
   "author": {

--- a/app/utils/metrics.js
+++ b/app/utils/metrics.js
@@ -16,13 +16,26 @@
  */
 
 import _ from 'lodash';
+import * as actionTypes from '../constants/actionTypes';
+
+const ADD_PATIENT_EVENTS = [
+  actionTypes.UPLOAD_REQUEST,
+  actionTypes.UPLOAD_FAILURE,
+  actionTypes.UPLOAD_SUCCESS,
+];
 
 const NONE_PROVIDED = 'No Event Name Provided';
 
 export function createMetricsTracker(api) {
   return (store) => (next) => (action) => {
-    let { selectedClinicId } = store.getState();
-    let defaultProperties = selectedClinicId ? { clinicId: selectedClinicId } : {};
+    const { selectedClinicId, uploadTargetUser } = store.getState();
+    const defaultProperties = {};
+    if (selectedClinicId) {
+      _.extend(defaultProperties, { clinicId: selectedClinicId });
+      if (_.includes(ADD_PATIENT_EVENTS, action.type)) {
+        _.extend(defaultProperties, { patientID: uploadTargetUser });
+      }
+    }
     if (_.get(action, 'meta.metric', null) !== null) {
       api.metrics.track(
         _.get(action, 'meta.metric.eventName', NONE_PROVIDED),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.40.1-new-clinics.13",
+  "version": "2.40.1-add-patientId.1",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.prod.js",


### PR DESCRIPTION
For [UPLOAD-723], adds `patientID` properties to a handful of relevant `Upload` metrics for new clinics.

[UPLOAD-723]: https://tidepool.atlassian.net/browse/UPLOAD-723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ