### PR TITLE
[UPLOAD-771] clinic remember me redirects

### DIFF
--- a/app/actions/async.js
+++ b/app/actions/async.js
@@ -117,16 +117,51 @@ export function doAppInit(opts, servicesToInit) {
           }
 
           api.user.initializationInfo((err, results) => {
+            const [ user, profile, memberships, associatedAccounts, clinics ] = results;
             if (err) {
               return dispatch(sync.initializeAppFailure(err));
             }
             dispatch(sync.initializeAppSuccess());
             dispatch(doVersionCheck());
             dispatch(sync.setUserInfoFromToken({
-              user: results[0],
-              profile: results[1],
-              memberships: results[2]
+              user: user,
+              profile: profile,
+              memberships: memberships
             }));
+            dispatch(sync.getClinicsForClinicianSuccess(clinics, user.userid));
+            const isClinic = personUtils.isClinic(user);
+            if(!_.isEmpty(clinics)){
+              if (clinics.length == 1) { // select clinic and go to clinic user select page
+                let clinicId = _.get(clinics,'0.clinic.id',null);
+                dispatch(fetchPatientsForClinic(clinicId));
+                dispatch(sync.selectClinic(clinicId));
+                return dispatch(
+                  setPage(pages.CLINIC_USER_SELECT, actionSources.USER, {
+                    metric: { eventName: metrics.CLINIC_SEARCH_DISPLAYED },
+                  })
+                );
+              }
+              if (clinics.length > 1) { // more than one clinic - go to workspace switch
+                return dispatch(
+                  setPage(pages.WORKSPACE_SWITCH, actionSources.USER, {
+                    metric: { eventName: metrics.WORKSPACE_SWITCH_DISPLAYED}
+                  })
+                );
+              }
+            }
+            if(isClinic){ // "old" style clinic account without new clinic
+              return dispatch(
+                setPage(pages.CLINIC_USER_SELECT, actionSources.USER, {
+                  metric: { eventName: metrics.CLINIC_SEARCH_DISPLAYED },
+                })
+              );
+            }
+            // detect if a DSA here and redirect to data storage screen
+            const { targetUsersForUpload } = getState();
+            if (_.isEmpty(targetUsersForUpload)) {
+              return dispatch(setPage(pages.NO_UPLOAD_TARGETS));
+            }
+
             const { uploadTargetUser } = getState();
             if (uploadTargetUser !== null) {
               dispatch(sync.setBlipViewDataUrl(

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.44.0",
+  "version": "2.44.0-remember-me.1",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.prod.js",
   "author": {

--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -107,11 +107,13 @@ api.makeBlipUrl = (tail) => tidepool.makeBlipUrl(tail);
 api.user = {};
 
 api.user.initializationInfo = (cb) => {
+  const userId = tidepool.getUserId();
   async.series([
     api.user.account,
     api.user.loggedInProfile,
     api.user.getUploadGroups,
     api.user.getAssociatedAccounts,
+    (callback) => { api.clinics.getClinicsForClinician(userId, callback); },
   ], cb);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.44.0",
+  "version": "2.44.0-remember-me.1",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.prod.js",

--- a/test/app/actions/async.test.js
+++ b/test/app/actions/async.test.js
@@ -178,7 +178,7 @@ describe('Asynchronous Actions', () => {
             getVersions: (cb) => { cb(null, {uploaderMinimum: config.version}); }
           },
           user: {
-            initializationInfo: (cb) => { cb(null, [pwd.user, pwd.profile, pwd.memberships] ); }
+            initializationInfo: (cb) => { cb(null, [pwd.user, pwd.profile, pwd.memberships, {}, []] ); }
           }
         },
         device: {
@@ -239,6 +239,10 @@ describe('Asynchronous Actions', () => {
           meta: {source: actionSources[actionTypes.SET_USER_INFO_FROM_TOKEN]}
         },
         {
+          type: actionTypes.GET_CLINICS_FOR_CLINICIAN_SUCCESS,
+          payload: {clinicianId: pwd.user.userid, clinics: []},
+        },
+        {
           type: actionTypes.SET_BLIP_VIEW_DATA_URL,
           payload: {url: `http://www.acme.com/patients/${pwd.user.userid}/data`},
           meta: {source: actionSources[actionTypes.SET_BLIP_VIEW_DATA_URL]}
@@ -267,8 +271,413 @@ describe('Asynchronous Actions', () => {
         allUsers: { [pwd.user.userid]: pwd.user },
         uploadTargetUser: pwd.user.userid,
         working: { initializingApp: { inProgress: true } },
+        targetUsersForUpload: pwd.memberships.map(user=>user.userid),
       };
       const store = mockStore(state);
+      store.dispatch(async.doAppInit(config, servicesToInit));
+      const actions = store.getActions();
+      expect(actions).to.deep.equal(expectedActions);
+    });
+  });
+
+  describe('doAppInit [saved session token, verified clinic account]', () => {
+    test('should dispatch INIT_APP_REQUEST, HIDE_UNAVAILABLE_DEVICES, SET_FORGOT_PASSWORD_URL, SET_SIGNUP_URL, SET_NEW_PATIENT_URL, SET_BLIP_URL, INIT_APP_SUCCESS, VERSION_CHECK_REQUEST, VERSION_CHECK_SUCCESS, SET_USER_INFO_FROM_TOKEN, GET_CLINICS_FOR_CLINICIAN_SUCCESS, and SET_PAGE (CLINIC_USER_SELECT) actions', () => {
+      const userObj = {user: {userid: 'abc123', roles: ['clinic']}};
+      const profile = {fullName: 'Jane Doe'};
+      const memberships = [{userid: 'def456'}, {userid: 'ghi789'}];
+      const clinics = [];
+      const config = {
+        os: 'test',
+        version: '0.100.0',
+        API_URL: 'http://www.acme.com'
+      };
+      const servicesToInit = {
+        api: {
+          init: (cb) => { cb(null, {token: 'iAmAToken'}); },
+          makeBlipUrl: (path) => {
+            return 'http://www.acme.com' + path;
+          },
+          setHosts: _.noop,
+          upload: {
+            getVersions: (cb) => { cb(null, {uploaderMinimum: config.version}); }
+          },
+          user: {
+            initializationInfo: (cb) => { cb(null, [userObj.user, profile, memberships, {}, clinics] ); },
+            loginExtended: (creds, opts, cb) => cb(null, [userObj, profile, memberships]),
+            getAssociatedAccounts: (cb) => cb(null, {
+              patients: memberships,
+              dataDonationAccounts: [],
+              careTeam: [],
+            }),
+          },
+          clinics: {
+            getClinicsForClinician: (clinician, options, cb) => cb(null, []),
+          },
+        },
+        device: {
+          init: (opts, cb) => { cb(); }
+        },
+        localStore: {
+          init: (opts, cb) => { cb(); },
+          getInitialState: _.noop,
+          getItem: () => null
+        },
+        log: _.noop
+      };
+
+      const expectedActions = [
+        {
+          type: actionTypes.INIT_APP_REQUEST,
+          meta: {source: actionSources[actionTypes.INIT_APP_REQUEST]}
+        },
+        {
+          type: actionTypes.HIDE_UNAVAILABLE_DEVICES,
+          payload: {os: 'test'},
+          meta: {source: actionSources[actionTypes.HIDE_UNAVAILABLE_DEVICES]}
+        },
+        {
+          type: actionTypes.SET_FORGOT_PASSWORD_URL,
+          payload: {url: 'http://www.acme.com/request-password-from-uploader'},
+          meta: {source: actionSources[actionTypes.SET_FORGOT_PASSWORD_URL]}
+        },
+        {
+          type: actionTypes.SET_SIGNUP_URL,
+          payload: {url: 'http://www.acme.com/signup'},
+          meta: {source: actionSources[actionTypes.SET_SIGNUP_URL]}
+        },
+        {
+          type: actionTypes.SET_NEW_PATIENT_URL,
+          payload: {url: 'http://www.acme.com/patients/new'},
+          meta: {source: actionSources[actionTypes.SET_NEW_PATIENT_URL]}
+        },
+        {
+          type: actionTypes.SET_BLIP_URL,
+          payload: {url: 'http://www.acme.com/'},
+          meta: {source: actionSources[actionTypes.SET_BLIP_URL]}
+        },
+        {
+          type: actionTypes.INIT_APP_SUCCESS,
+          meta: {source: actionSources[actionTypes.INIT_APP_SUCCESS]}
+        },
+        {
+          type: actionTypes.VERSION_CHECK_REQUEST,
+          meta: {source: actionSources[actionTypes.VERSION_CHECK_REQUEST]}
+        },
+        {
+          type: actionTypes.VERSION_CHECK_SUCCESS,
+          meta: {source: actionSources[actionTypes.VERSION_CHECK_SUCCESS]}
+        },
+        {
+          type: actionTypes.SET_USER_INFO_FROM_TOKEN,
+          payload: {user: userObj.user, profile: profile, memberships: memberships},
+          meta: {source: actionSources[actionTypes.SET_USER_INFO_FROM_TOKEN]}
+        },
+        {
+          type: actionTypes.GET_CLINICS_FOR_CLINICIAN_SUCCESS,
+          payload: {clinicianId: userObj.user.userid, clinics: []},
+        },
+        {
+          type: '@@router/CALL_HISTORY_METHOD',
+          payload: {
+            args: [ {
+              pathname: '/clinic_user_select',
+              state: {
+                meta: {
+                  metric: {eventName: metrics.CLINIC_SEARCH_DISPLAYED},
+                  source: actionSources.USER
+                }
+              }
+            } ],
+            method: 'push'
+          }
+        },
+      ];
+      const store = mockStore({
+        allUsers: { [userObj.user.userid]: userObj.user },
+        targetUsersForUpload: ['def456', 'ghi789'],
+        working: { initializingApp: { inProgress: true } },
+      });
+      store.dispatch(async.doAppInit(config, servicesToInit));
+      const actions = store.getActions();
+      expect(actions).to.deep.equal(expectedActions);
+    });
+  });
+
+  describe('doAppInit [saved session token, new clinic account]', () => {
+    test('should dispatch INIT_APP_REQUEST, HIDE_UNAVAILABLE_DEVICES, SET_FORGOT_PASSWORD_URL, SET_SIGNUP_URL, SET_NEW_PATIENT_URL, SET_BLIP_URL, INIT_APP_SUCCESS, VERSION_CHECK_REQUEST, VERSION_CHECK_SUCCESS, SET_USER_INFO_FROM_TOKEN, GET_CLINICS_FOR_CLINICIAN_SUCCESS, FETCH_PATIENTS_FOR_CLINIC_REQUEST, FETCH_PATIENTS_FOR_CLINIC_SUCCESS, SELECT_CLINIC, and SET_PAGE (CLINIC_USER_SELECT) actions', () => {
+      const userObj = {user: {userid: 'abc123', roles: ['clinician']}};
+      const profile = {fullName: 'Jane Doe'};
+      const memberships = [{userid: 'def456'}, {userid: 'ghi789'}];
+      const clinics = [{ clinic: { id: 'clinicId' } }];
+      const config = {
+        os: 'test',
+        version: '0.100.0',
+        API_URL: 'http://www.acme.com'
+      };
+      const servicesToInit = {
+        api: {
+          init: (cb) => { cb(null, {token: 'iAmAToken'}); },
+          makeBlipUrl: (path) => {
+            return 'http://www.acme.com' + path;
+          },
+          setHosts: _.noop,
+          upload: {
+            getVersions: (cb) => { cb(null, {uploaderMinimum: config.version}); }
+          },
+          user: {
+            initializationInfo: (cb) => { cb(null, [userObj.user, profile, memberships, {}, clinics] ); },
+            loginExtended: (creds, opts, cb) =>
+              cb(null, [userObj, profile, memberships]),
+            getAssociatedAccounts: (cb) =>
+              cb(null, {
+                patients: memberships,
+                dataDonationAccounts: [],
+                careTeam: [],
+              }),
+          },
+          clinics: {
+            getClinicsForClinician: (clinician, options, cb) =>
+              cb(null, [{ clinic: { id: 'clinicId' } }]),
+            getPatientsForClinic: (clinicId, options, cb) =>
+              cb(null, { data: [{ patient: 'patient1' }], meta: { count: 1 } }),
+          },
+        },
+        device: {
+          init: (opts, cb) => { cb(); }
+        },
+        localStore: {
+          init: (opts, cb) => { cb(); },
+          getInitialState: _.noop,
+          getItem: () => null
+        },
+        log: _.noop
+      };
+
+      const expectedActions = [
+        {
+          type: actionTypes.INIT_APP_REQUEST,
+          meta: {source: actionSources[actionTypes.INIT_APP_REQUEST]}
+        },
+        {
+          type: actionTypes.HIDE_UNAVAILABLE_DEVICES,
+          payload: {os: 'test'},
+          meta: {source: actionSources[actionTypes.HIDE_UNAVAILABLE_DEVICES]}
+        },
+        {
+          type: actionTypes.SET_FORGOT_PASSWORD_URL,
+          payload: {url: 'http://www.acme.com/request-password-from-uploader'},
+          meta: {source: actionSources[actionTypes.SET_FORGOT_PASSWORD_URL]}
+        },
+        {
+          type: actionTypes.SET_SIGNUP_URL,
+          payload: {url: 'http://www.acme.com/signup'},
+          meta: {source: actionSources[actionTypes.SET_SIGNUP_URL]}
+        },
+        {
+          type: actionTypes.SET_NEW_PATIENT_URL,
+          payload: {url: 'http://www.acme.com/patients/new'},
+          meta: {source: actionSources[actionTypes.SET_NEW_PATIENT_URL]}
+        },
+        {
+          type: actionTypes.SET_BLIP_URL,
+          payload: {url: 'http://www.acme.com/'},
+          meta: {source: actionSources[actionTypes.SET_BLIP_URL]}
+        },
+        {
+          type: actionTypes.INIT_APP_SUCCESS,
+          meta: {source: actionSources[actionTypes.INIT_APP_SUCCESS]}
+        },
+        {
+          type: actionTypes.VERSION_CHECK_REQUEST,
+          meta: {source: actionSources[actionTypes.VERSION_CHECK_REQUEST]}
+        },
+        {
+          type: actionTypes.VERSION_CHECK_SUCCESS,
+          meta: {source: actionSources[actionTypes.VERSION_CHECK_SUCCESS]}
+        },
+        {
+          type: actionTypes.SET_USER_INFO_FROM_TOKEN,
+          payload: {user: userObj.user, profile: profile, memberships: memberships},
+          meta: {source: actionSources[actionTypes.SET_USER_INFO_FROM_TOKEN]}
+        },
+        {
+          type: actionTypes.GET_CLINICS_FOR_CLINICIAN_SUCCESS,
+          payload: {
+            clinicianId: 'abc123',
+            clinics: clinics,
+          },
+        },
+        {
+          type: actionTypes.FETCH_PATIENTS_FOR_CLINIC_REQUEST
+        },
+        {
+          type: actionTypes.FETCH_PATIENTS_FOR_CLINIC_SUCCESS,
+          payload: {
+            clinicId: 'clinicId',
+            patients: [{ patient: 'patient1' }],
+            count: 1,
+          }
+        },
+        {
+          type: actionTypes.SELECT_CLINIC,
+          payload: {clinicId:'clinicId'}
+        },
+        {
+          type: '@@router/CALL_HISTORY_METHOD',
+          payload: {
+            args: [ {
+              pathname: '/clinic_user_select',
+              state: {
+                meta: {
+                  metric: {eventName: metrics.CLINIC_SEARCH_DISPLAYED},
+                  source: actionSources.USER
+                }
+              }
+            } ],
+            method: 'push'
+          }
+        },
+      ];
+
+      const store = mockStore({
+        allUsers: { [userObj.user.userid]: userObj.user },
+        targetUsersForUpload: ['def456', 'ghi789'],
+        working: { initializingApp: { inProgress: true } },
+      });
+      store.dispatch(async.doAppInit(config, servicesToInit));
+      const actions = store.getActions();
+      expect(actions).to.deep.equal(expectedActions);
+    });
+  });
+
+  describe('doAppInit [saved session token, new clinic account] multiple clinics', () => {
+    test('should dispatch INIT_APP_REQUEST, HIDE_UNAVAILABLE_DEVICES, SET_FORGOT_PASSWORD_URL, SET_SIGNUP_URL, SET_NEW_PATIENT_URL, SET_BLIP_URL, INIT_APP_SUCCESS, VERSION_CHECK_REQUEST, VERSION_CHECK_SUCCESS, SET_USER_INFO_FROM_TOKEN, GET_CLINICS_FOR_CLINICIAN_SUCCESS, and SET_PAGE (WORKSPACE_SWITCH) actions', () => {
+      const userObj = {user: {userid: 'abc123', roles: ['clinic']}};
+      const profile = {fullName: 'Jane Doe'};
+      const memberships = [{userid: 'def456'}, {userid: 'ghi789'}];
+      const clinics = [
+        { clinic: { id: 'clinicId' } },
+        { clinic: { id: 'clinicId2' } },
+      ];
+      const config = {
+        os: 'test',
+        version: '0.100.0',
+        API_URL: 'http://www.acme.com'
+      };
+      const servicesToInit = {
+        api: {
+          init: (cb) => { cb(null, {token: 'iAmAToken'}); },
+          makeBlipUrl: (path) => {
+            return 'http://www.acme.com' + path;
+          },
+          setHosts: _.noop,
+          upload: {
+            getVersions: (cb) => { cb(null, {uploaderMinimum: config.version}); }
+          },
+          user: {
+            initializationInfo: (cb) => { cb(null, [userObj.user, profile, memberships, {}, clinics] ); },
+            loginExtended: (creds, opts, cb) =>
+              cb(null, [userObj, profile, memberships]),
+            getAssociatedAccounts: (cb) =>
+              cb(null, {
+                patients: memberships,
+                dataDonationAccounts: [],
+                careTeam: [],
+              }),
+          },
+          clinics: {
+            getClinicsForClinician: (clinician, options, cb) =>
+              cb(null, clinics),
+            getPatientsForClinic: (clinicId, options, cb) =>
+              cb(null, { data: [{ patient: 'patient1' }], meta: { count: 1 } }),
+          },
+        },
+        device: {
+          init: (opts, cb) => { cb(); }
+        },
+        localStore: {
+          init: (opts, cb) => { cb(); },
+          getInitialState: _.noop,
+          getItem: () => null
+        },
+        log: _.noop
+      };
+
+      const expectedActions = [
+        {
+          type: actionTypes.INIT_APP_REQUEST,
+          meta: {source: actionSources[actionTypes.INIT_APP_REQUEST]}
+        },
+        {
+          type: actionTypes.HIDE_UNAVAILABLE_DEVICES,
+          payload: {os: 'test'},
+          meta: {source: actionSources[actionTypes.HIDE_UNAVAILABLE_DEVICES]}
+        },
+        {
+          type: actionTypes.SET_FORGOT_PASSWORD_URL,
+          payload: {url: 'http://www.acme.com/request-password-from-uploader'},
+          meta: {source: actionSources[actionTypes.SET_FORGOT_PASSWORD_URL]}
+        },
+        {
+          type: actionTypes.SET_SIGNUP_URL,
+          payload: {url: 'http://www.acme.com/signup'},
+          meta: {source: actionSources[actionTypes.SET_SIGNUP_URL]}
+        },
+        {
+          type: actionTypes.SET_NEW_PATIENT_URL,
+          payload: {url: 'http://www.acme.com/patients/new'},
+          meta: {source: actionSources[actionTypes.SET_NEW_PATIENT_URL]}
+        },
+        {
+          type: actionTypes.SET_BLIP_URL,
+          payload: {url: 'http://www.acme.com/'},
+          meta: {source: actionSources[actionTypes.SET_BLIP_URL]}
+        },
+        {
+          type: actionTypes.INIT_APP_SUCCESS,
+          meta: {source: actionSources[actionTypes.INIT_APP_SUCCESS]}
+        },
+        {
+          type: actionTypes.VERSION_CHECK_REQUEST,
+          meta: {source: actionSources[actionTypes.VERSION_CHECK_REQUEST]}
+        },
+        {
+          type: actionTypes.VERSION_CHECK_SUCCESS,
+          meta: {source: actionSources[actionTypes.VERSION_CHECK_SUCCESS]}
+        },
+        {
+          type: actionTypes.SET_USER_INFO_FROM_TOKEN,
+          payload: {user: userObj.user, profile: profile, memberships: memberships},
+          meta: {source: actionSources[actionTypes.SET_USER_INFO_FROM_TOKEN]}
+        },
+        {
+          type: actionTypes.GET_CLINICS_FOR_CLINICIAN_SUCCESS,
+          payload: {
+            clinicianId: 'abc123',
+            clinics: clinics,
+          },
+        },
+        {
+          type: '@@router/CALL_HISTORY_METHOD',
+          payload: {
+            args: [ {
+              pathname: '/workspace_switch',
+              state: {
+                meta: {
+                  metric: {eventName: metrics.WORKSPACE_SWITCH_DISPLAYED},
+                  source: actionSources.USER
+                }
+              }
+            } ],
+            method: 'push'
+          }
+        },
+      ];
+      const store = mockStore({
+        allUsers: { [pwd.user.userid]: pwd.user },
+        targetUsersForUpload: ['def456', 'ghi789'],
+        working: { initializingApp: { inProgress: true } },
+      });
       store.dispatch(async.doAppInit(config, servicesToInit));
       const actions = store.getActions();
       expect(actions).to.deep.equal(expectedActions);


### PR DESCRIPTION
To address [UPLOAD-771], replicates the clinic fetching and redirect logic from `login` in the `appInit` which will run when session information is restored from the saved token in localstorage (when `Remember me` is selected and Uploader is relaunched)