### PR TITLE
[UPLOAD-1045] token refresh

### DIFF
--- a/app/keycloak.js
+++ b/app/keycloak.js
@@ -11,6 +11,16 @@ import { ipcRenderer } from 'electron';
 export let keycloak = null;
 
 let _keycloakConfig = {};
+let refreshTimeout = null;
+
+export const setTokenRefresh = (keycloak) => {
+  if (refreshTimeout) {
+    clearTimeout(refreshTimeout);
+    refreshTimeout = null;
+  }
+  var expiresIn = (keycloak.tokenParsed['exp'] - new Date().getTime() / 1000 + keycloak.timeSkew) * 1000;
+  refreshTimeout = setTimeout(() => { keycloak.updateToken(-1); }, expiresIn - 10000);
+};
 
 const updateKeycloakConfig = (info, store) => {
   if (!_.isEqual(_keycloakConfig, info)) {
@@ -86,6 +96,7 @@ const onKeycloakTokens = (store) => (tokens) => {
     if (!store.getState().loggedInUser) {
       store.dispatch(async.doLogin());
     }
+    setTokenRefresh(keycloak);
   }
 };
 

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.52.0",
+  "version": "2.53.0-token-refresh.1",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.prod.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.52.0",
+  "version": "2.53.0-token-refresh.1",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.prod.js",


### PR DESCRIPTION
to handle [UPLOAD-1045], preemptively refreshing the auth token 10 seconds prior to expiry as opposed to precisely at time of expiry

Uploader analog of https://github.com/tidepool-org/blip/pull/1220