### PR TITLE
[UPLOAD-1040] update 401/403 check to handle FSA

### DIFF
--- a/app/keycloak.js
+++ b/app/keycloak.js
@@ -131,7 +131,11 @@ export const keycloakMiddleware = (api) => (storeAPI) => (next) => (action) => {
         action?.error?.status === 401 ||
         action?.error?.originalError?.status === 401 ||
         action?.error?.status === 403 ||
-        action?.error?.originalError?.status === 403
+        action?.error?.originalError?.status === 403 ||
+        action?.payload?.status === 401 ||
+        action?.payload?.originalError?.status === 401 ||
+        action?.payload?.status === 403 ||
+        action?.payload?.originalError?.status === 403
       ) {
         // on any action with a 401 or 403, we try to refresh to keycloak token to verify
         // if the user is still logged in

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.52.0",
+  "version": "2.53.0-handle-fsa.1",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.prod.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.52.0",
+  "version": "2.53.0-handle-fsa.1",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.prod.js",


### PR DESCRIPTION
for [UPLOAD-1040], updates the middleware that checks actions for 401/403 and triggers a token refresh check to properly inspect Flux Standard Actions alongside our Tidepool Standard Action format.