### PR TITLE
[UPLOAD-1123] prevent hashchange events when authenticated

### DIFF
--- a/app/keycloak.js
+++ b/app/keycloak.js
@@ -219,8 +219,6 @@ export const keycloakMiddleware = (api) => (storeAPI) => (next) => (action) => {
   return next(action);
 };
 
-let hashChanges = [];
-
 let keyCount = 0;
 
 export const KeycloakWrapper = (props) => {
@@ -250,10 +248,9 @@ export const KeycloakWrapper = (props) => {
   // incrementing externally defined `key` forces unmount/remount as provider doesn't expect to
   // have the authClient refreshed and only sets up refresh timeout on mount
   const onHashChange = useCallback(() => {
-    // we only want to do this once per hash since people can hit the launch button multiple times
-    if (!hashChanges.includes(window.location.hash)) {
-      hashChanges.push(window.location.hash);
-
+    // we only want to do this when unauthenticated since people can hit the
+    // launch button multiple times
+    if (!keycloak?.authenticated) {
       keycloak = new Keycloak({
         url: keycloakConfig.url,
         realm: keycloakConfig.realm,

--- a/app/keycloak.js
+++ b/app/keycloak.js
@@ -42,7 +42,10 @@ const updateKeycloakConfig = (info, store) => {
   }
 };
 
+let latestKeycloakEvent = null;
+
 const onKeycloakEvent = (store) => (event, error) => {
+  latestKeycloakEvent = event;
   switch (event) {
     case 'onReady': {
       let logoutUrl = keycloak.createLogoutUrl({
@@ -116,7 +119,7 @@ const onKeycloakTokens = (store) => (tokens) => {
       if (tokens.token !== keycloak?.token) {
         if (rollbar) {
           rollbar.info('keycloak token mismatch', {
-            keycloakToken: jose.decodeJwt(keycloak?.token),
+            keycloakToken: keycloak?.token ? jose.decodeJwt(keycloak?.token) : {},
             tokensToken: tokenParsed,
           });
         }
@@ -137,6 +140,17 @@ const onKeycloakTokens = (store) => (tokens) => {
       return;
     }
   } else {
+    const expectedEvents = [
+      'onReady',
+      'onAuthLogout',
+      'onAuthRefreshError',
+      'onAuthError',
+      'onInitError'
+    ];
+    if (expectedEvents.includes(latestKeycloakEvent)) {
+      return;
+    }
+
     // if we don't have a token, we can't save the session
     if(rollbar) {
       rollbar.error('keycloak token missing', {
@@ -205,6 +219,8 @@ export const keycloakMiddleware = (api) => (storeAPI) => (next) => (action) => {
   return next(action);
 };
 
+let hashChanges = [];
+
 let keyCount = 0;
 
 export const KeycloakWrapper = (props) => {
@@ -234,13 +250,18 @@ export const KeycloakWrapper = (props) => {
   // incrementing externally defined `key` forces unmount/remount as provider doesn't expect to
   // have the authClient refreshed and only sets up refresh timeout on mount
   const onHashChange = useCallback(() => {
-    keycloak = new Keycloak({
-      url: keycloakConfig.url,
-      realm: keycloakConfig.realm,
-      clientId: 'tidepool-uploader-sso',
-    });
-    keyCount++;
-    forceUpdate();
+    // we only want to do this once per hash since people can hit the launch button multiple times
+    if (!hashChanges.includes(window.location.hash)) {
+      hashChanges.push(window.location.hash);
+
+      keycloak = new Keycloak({
+        url: keycloakConfig.url,
+        realm: keycloakConfig.realm,
+        clientId: 'tidepool-uploader-sso',
+      });
+      keyCount++;
+      forceUpdate();
+    }
   }, [keycloakConfig.realm, keycloakConfig.url, blipRedirect]);
 
   useEffect(() => {
@@ -249,6 +270,16 @@ export const KeycloakWrapper = (props) => {
       window.removeEventListener('hashchange', onHashChange, false);
     };
   }, [onHashChange]);
+
+  // clear the refresh timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (refreshTimeout) {
+        clearTimeout(refreshTimeout);
+        refreshTimeout = null;
+      }
+    };
+  }, []);
 
   if (keycloakConfig.url && keycloakConfig.instantiated && blipRedirect) {
     return (

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.54.2-session-launch.1",
+  "version": "2.54.2-session-launch.2",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.prod.js",
   "author": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.54.1",
+  "version": "2.54.2-session-launch.1",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.prod.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.54.2-session-launch.1",
+  "version": "2.54.2-session-launch.2",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.prod.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.54.1",
+  "version": "2.54.2-session-launch.1",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.prod.js",


### PR DESCRIPTION
For [UPLOAD-1123]

- checks for the latest keycloak event to be more judicious with error state logging
- only process hashchange events when not authenticated to prevent trying to re-process hashes that come in from repeat clicking the `Launch Uploader` button in Web
- clear the refreshTimeout if it exists on component unmount

[UPLOAD-1123]: https://tidepool.atlassian.net/browse/UPLOAD-1123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ