### PR TITLE
[UPLOAD-1158] notary tool update

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ We use the following environment variables on the CI server:
 |----------|-----------|-------|
 | APPLEID                  | MacOS    | Notarization |
 | APPLEIDPASS              | MacOS    | Notarization |
+| TEAMID                   | MacOS    | Notarization |
 | AWS_ACCESS_KEY_ID        | Both     | S3 builds and AV e-mails |
 | AWS_SECRET_ACESS_KEY     | Both     | S3 builds and AV e-mails |
 | CSC_FOR_PULL_REQUEST     | Both     | `true`, code signing for PR |
@@ -227,7 +228,7 @@ $ npm run package -- --[option]
 
 To package the app on your local machine, you need to set the `ROLLBAR_POST_TOKEN` environment variable to send telemetry data to Rollbar. You can get one for free from https://rollbar.com
 
-macOS: To notarize the app so that it will run on macOS Mojave, you need to set the environment variables `APPLEID` and `APPLEIDPASS`. Note that you need to set an app-specific password in https://appleid.apple.com for this to work.
+macOS: To notarize the app so that it will run on macOS Mojave, you need to set the environment variables `APPLEID`, `APPLEIDPASS`, and `TEAMID`. Note that you need to set an app-specific password in https://appleid.apple.com for this to work.
 
 Note that you'll need to build Windows builds on a Windows machine, and MacOS builds on a Mac.
 

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.55.1-notary-tool.1",
+  "version": "2.55.1-notary-tool.2",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.prod.js",
   "author": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.55.1-verio-ble-time-update.4",
+  "version": "2.55.1-notary-tool.1",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.prod.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.55.1-verio-ble-time-update.4",
+  "version": "2.55.1-notary-tool.1",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.prod.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.55.1-notary-tool.1",
+  "version": "2.55.1-notary-tool.2",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.prod.js",

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -15,6 +15,7 @@ exports.default = async function notarizing(context) {
     appPath: `${appOutDir}/${appName}.app`,
     appleId: process.env.APPLEID,
     appleIdPassword: process.env.APPLEIDPASS,
+    teamId: process.env.TEAMID,
     tool: 'notarytool',
   });
 };

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -15,5 +15,6 @@ exports.default = async function notarizing(context) {
     appPath: `${appOutDir}/${appName}.app`,
     appleId: process.env.APPLEID,
     appleIdPassword: process.env.APPLEIDPASS,
+    tool: 'notarytool',
   });
 };


### PR DESCRIPTION
For [UPLOAD-1158], in order to handle Apple's deprecation of the legacy notary tool

[UPLOAD-1158]: https://tidepool.atlassian.net/browse/UPLOAD-1158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ