### PR TITLE
Add error message that Dexcom G7 receiver is unsupported (UPLOAD-1168)

### DIFF
--- a/app/actions/async.js
+++ b/app/actions/async.js
@@ -342,8 +342,8 @@ export function doDeviceUpload(driverId, opts = {}, utc) {
         }
 
         if (err === 'E_G7_UNSUPPORTED') {
-          displayErr = new Error(ErrorMessages.E_UNSUPPORTED);
-          deviceDetectErrProps.code = 'E_UNSUPPORTED';
+          displayErr = new Error(ErrorMessages.E_G7_UNSUPPORTED);
+          deviceDetectErrProps.code = 'E_G7_UNSUPPORTED';
         }
 
         displayErr.originalError = err;

--- a/app/actions/async.js
+++ b/app/actions/async.js
@@ -341,6 +341,11 @@ export function doDeviceUpload(driverId, opts = {}, utc) {
           displayErr.linkText = 'Please see this support article.';
         }
 
+        if (err === 'E_G7_UNSUPPORTED') {
+          displayErr = new Error(ErrorMessages.E_UNSUPPORTED);
+          deviceDetectErrProps.code = 'E_UNSUPPORTED';
+        }
+
         displayErr.originalError = err;
         if (process.env.NODE_ENV !== 'test') {
           deviceDetectErrProps = await actionUtils.sendToRollbar(displayErr, deviceDetectErrProps);

--- a/app/constants/errorMessages.js
+++ b/app/constants/errorMessages.js
@@ -39,6 +39,7 @@ module.exports = {
   E_UNPLUG_CABLE_AND_RETRY: 'Please unplug cable from computer and try again',
   E_UNSUPPORTED: 'Sorry, we don\'t support this device yet',
   E_LIBRE2_UNSUPPORTED: 'Uploading Libre 2 data?',
+  E_G7_UNSUPPORTED: 'Dexcom G7 Receiver is not yet supported.',
   E_BLUETOOTH_OFF: 'Make sure your Bluetooth is switched on',
   E_DEXCOM_CONNECTION: 'Tidepool is having trouble connecting to your Dexcom receiver. Please make sure your other Dexcom uploading software programs are closed (like Dexcom Clarity or Glooko/Diasend). You can also try using another micro-USB cable. Some micro-USB cables are designed to carry a signal for power only.',
   E_USB_CABLE: 'Your device doesn\'t appear to be connected. You can try using another USB cable, as some USB cables are designed to carry a signal for power only.',

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.56.1",
+  "version": "2.56.1-g7-unsupported.1",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.prod.js",
   "author": {

--- a/lib/core/device.js
+++ b/lib/core/device.js
@@ -422,6 +422,11 @@ device.detect = (driverId, options, cb) => {
       productId: usbProductId,
     };
 
+    if (driverId === 'Dexcom' && devdata.vendorId === 8867 && devdata.productId === 72) {
+      // This is an attempt to upload a Dexcom G7, which is not yet supported
+      return cb('E_G7_UNSUPPORTED');
+    }
+
     if (driverManifest.bitrate) {
       devdata.bitrate = driverManifest.bitrate;
     }

--- a/lib/core/driverManifests.js
+++ b/lib/core/driverManifests.js
@@ -22,7 +22,8 @@ const driverManifests = {
   Dexcom: {
     mode: 'serial',
     usb: [
-      { vendorId: 8867, productId: 71, driver: 'cdc-acm' },
+      { vendorId: 8867, productId: 71, driver: 'cdc-acm' }, // G4, G5 and G6
+      { vendorId: 8867, productId: 72, driver: 'cdc-acm' }, // G7, not supported yet
     ],
   },
   AbbottPrecisionXtra: {

--- a/locales/en/translation.missing.json
+++ b/locales/en/translation.missing.json
@@ -45,5 +45,6 @@
   "Plug cable into meter and then connect to computer": "Plug cable into meter and then connect to computer",
   "Please unplug cable from computer and try again": "Please unplug cable from computer and try again",
   "Plug cable into meter and then connect cable to computer": "Plug cable into meter and then connect cable to computer",
-  "True Metrix, True Metrix Pro & True Metrix Air: Place meter in cradle • True Metrix Go: Plug in meter with micro-USB cable": "True Metrix, True Metrix Pro & True Metrix Air: Place meter in cradle • True Metrix Go: Plug in meter with micro-USB cable"
+  "True Metrix, True Metrix Pro & True Metrix Air: Place meter in cradle • True Metrix Go: Plug in meter with micro-USB cable": "True Metrix, True Metrix Pro & True Metrix Air: Place meter in cradle • True Metrix Go: Plug in meter with micro-USB cable",
+  "Dexcom G7 Receiver is not yet supported.": "Dexcom G7 Receiver is not yet supported."
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.56.1",
+  "version": "2.56.1-g7-unsupported.1",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.prod.js",


### PR DESCRIPTION
Addresses [UPLOAD-1168].

[UPLOAD-1168]: https://tidepool.atlassian.net/browse/UPLOAD-1168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ