### PR TITLE
Fix upload record (UPLOAD-1272)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tidepool-uploader",
   "productName": "tidepool-uploader",
-  "version": "2.57.0-fix-user-space.1",
+  "version": "2.57.0-fix-upload-record.1",
   "description": "Tidepool Project Universal Uploader",
   "main": "./main.prod.js",
   "author": {

--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -680,7 +680,9 @@ api.upload.toPlatform = (data, sessionInfo, progress, groupId, cb, uploadType = 
   async.waterfall([
     (callback) => {
       // generate digest
-      crypto.subtle.digest('SHA-256', new Uint8Array(`${sessionInfo.deviceId}_${sessionInfo.start}`)).then((digest) => {
+      const encoder = new TextEncoder();
+      const data = encoder.encode(`${sessionInfo.deviceId}_${sessionInfo.start}`);
+      crypto.subtle.digest('SHA-256', data).then((digest) => {
         const hex = Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2, '0')).join('');
         return hex;
       }).then((hexDigest) => {
@@ -754,7 +756,6 @@ api.upload.toPlatform = (data, sessionInfo, progress, groupId, cb, uploadType = 
         uploadItem.with_byUser(tidepool.getUserId());
       }
       uploadItem = uploadItem.done();
-
       api.log('create dataset');
 
       if (uploadType === 'dataservices') {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "dev": "cross-env START_HOT=1 yarn start-renderer-dev",
     "dev-web": "cross-env HOT=1 NODE_ENV=development webpack-dev-server --config webpack.config.web.dev.babel.js",
     "start-renderer-dev": "cross-env NODE_ENV=development webpack-dev-server --config webpack.config.renderer.dev.babel.js",
-    "start-main-dev": "cross-env HOT=1 NODE_ENV=development electron -r @babel/register ./app/main.dev.js",
+    "start-main-dev": "cross-env HOT=1 NODE_ENV=development electron --no-sandbox -r @babel/register ./app/main.dev.js",
     "server": "node server",
     "prepare-qa-build": "node -r @babel/register scripts/prepare-qa-build.js",
     "package": "npm run build-quiet && electron-builder -p always -c electron-builder-publish.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidepool-uploader",
-  "version": "2.57.0-fix-user-space.1",
+  "version": "2.57.0-fix-upload-record.1",
   "description": "Tidepool Project Universal Uploader",
   "private": true,
   "main": "main.prod.js",


### PR DESCRIPTION
There was an issue with the Jellyfish upload ID which prevented an upload record from being created. This in turn broke:

- device names in Blip
- delta uploads for Tandem and Omnipod
- device settings for Tandem and Omnipod

Hopefully this PR should fix all of that. Addresses [UPLOAD-1272].

[UPLOAD-1272]: https://tidepool.atlassian.net/browse/UPLOAD-1272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ